### PR TITLE
ops: disable automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,6 @@
     'helpers:pinGitHubActionDigests',
     ':dependencyDashboard',
     ':disableRateLimiting',
-    'github>homelab-peej/ping-server//.github/renovate/autoMerge.json5',
   ],
   dependencyDashboardTitle: 'Renovate Dashboard 🤖',
   suppressNotifications: [


### PR DESCRIPTION
Disable automerge while looking at semantic commit messages